### PR TITLE
Implement style presets and aspect ratios

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,41 @@
-# prompt_video
+# Prompt Video Pipeline
+
+This repository contains a skeleton implementation of a text-to-video
+pipeline optimized for the MacBook Pro M2. The goal is to demonstrate an
+architecture capable of converting text prompts into short multimedia
+videos using a sequence of lightweight processing steps.
+
+The current implementation contains a working text-to-image generator
+using Stable Diffusion through the `diffusers` library. Style presets,
+aspect ratio options and a simple upscaling step are implemented. The
+remaining stages are placeholders and should be expanded with Apple
+Silicon optimizations as described in the project specification.
+
+## Structure
+
+- `src/prompt_video/` – Python package with pipeline modules
+- `pyproject.toml` – project configuration and dependencies
+
+## Running
+
+Install dependencies (including PyTorch and Diffusers) and start the FastAPI server:
+
+```bash
+pip install -e .
+uvicorn prompt_video.main:app --reload
+```
+
+Then send a POST request to `/generate` with a JSON body containing your
+prompt and optional parameters:
+
+```json
+{
+  "prompt": "a tranquil forest",
+  "style": "cinematic",
+  "aspect_ratio": "16:9"
+}
+```
+
+The server responds with the path to the generated video (placeholder
+until later phases are implemented).
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,16 @@
+[project]
+name = "prompt_video"
+version = "0.1.0"
+requires-python = ">=3.10"
+dependencies = [
+    "fastapi",
+    "uvicorn[standard]",
+    "pillow",
+    "torch",
+    "diffusers",
+    "transformers",
+]
+
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/src/prompt_video/assembly.py
+++ b/src/prompt_video/assembly.py
@@ -1,0 +1,9 @@
+"""Final video assembly module using FFmpeg."""
+
+from typing import Any
+
+
+def assemble_video(video: Any, audio: Any, output_path: str) -> None:
+    """Combine video and audio into a final file."""
+    # TODO: integrate FFmpeg assembly with hardware acceleration
+    print(f"Assembling final video at {output_path}")

--- a/src/prompt_video/audio_generation.py
+++ b/src/prompt_video/audio_generation.py
@@ -1,0 +1,17 @@
+"""Audio generation module optimized for Apple Silicon."""
+
+from typing import Any
+
+
+def generate_voice(text: str, voice: str = "female") -> Any:
+    """Generate speech audio from text."""
+    # TODO: integrate actual TTS model (e.g., Coqui TTS or Bark)
+    print(f"Generating voice audio for text: {text!r} with voice: {voice}")
+    return None
+
+
+def generate_music(style: str = "ambient") -> Any:
+    """Generate background music."""
+    # TODO: integrate actual music model (e.g., MusicGen)
+    print(f"Generating music in style: {style}")
+    return None

--- a/src/prompt_video/image_to_video.py
+++ b/src/prompt_video/image_to_video.py
@@ -1,0 +1,14 @@
+"""Image to video generation module optimized for Apple Silicon."""
+
+from typing import Any
+
+
+def generate_video(image: Any, motion: str = "pan") -> Any:
+    """Generate a short video clip from an image.
+
+    This is a placeholder implementation. A real system would use models
+    such as AnimateDiff or Stable Video Diffusion.
+    """
+    # TODO: integrate actual video generation
+    print(f"Generating video using motion preset: {motion}")
+    return None

--- a/src/prompt_video/lip_sync.py
+++ b/src/prompt_video/lip_sync.py
@@ -1,0 +1,10 @@
+"""Lip sync processing module optimized for Apple Silicon."""
+
+from typing import Any
+
+
+def apply_lip_sync(video: Any, audio: Any) -> Any:
+    """Apply lip sync to a video clip given speech audio."""
+    # TODO: integrate actual lip sync model (e.g., Wav2Lip)
+    print("Applying lip sync to video")
+    return None

--- a/src/prompt_video/main.py
+++ b/src/prompt_video/main.py
@@ -1,0 +1,32 @@
+"""FastAPI app exposing the text-to-video pipeline."""
+
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+from . import pipeline
+
+app = FastAPI(title="Prompt Video Pipeline")
+
+
+class GenerateRequest(BaseModel):
+    prompt: str
+    style: str = "photographic"
+    aspect_ratio: str = "1:1"
+    motion: str = "pan"
+    voice: str = "female"
+    music_style: str = "ambient"
+
+
+@app.post("/generate")
+async def generate(req: GenerateRequest):
+    output_path = "output.mp4"
+    pipeline.generate_video_from_text(
+        req.prompt,
+        output_path,
+        style=req.style,
+        aspect_ratio=req.aspect_ratio,
+        motion=req.motion,
+        voice=req.voice,
+        music_style=req.music_style,
+    )
+    return {"output_path": output_path}

--- a/src/prompt_video/pipeline.py
+++ b/src/prompt_video/pipeline.py
@@ -1,0 +1,26 @@
+"""Sequential text-to-video pipeline optimized for the MacBook M2."""
+
+from typing import Any
+
+from . import text_to_image, image_to_video, audio_generation, lip_sync, assembly
+
+
+def generate_video_from_text(
+    prompt: str,
+    output_path: str,
+    *,
+    style: str = "photographic",
+    aspect_ratio: str = "1:1",
+    motion: str = "pan",
+    voice: str = "female",
+    music_style: str = "ambient",
+) -> None:
+    """Run the entire pipeline from text prompt to final video file."""
+    image = text_to_image.generate_image(prompt, style=style, aspect_ratio=aspect_ratio)
+    video = image_to_video.generate_video(image, motion=motion)
+    speech = audio_generation.generate_voice(prompt, voice=voice)
+    music = audio_generation.generate_music(style=music_style)
+    # Placeholder: mix speech and music
+    audio_track: Any = None
+    synced_video = lip_sync.apply_lip_sync(video, speech)
+    assembly.assemble_video(synced_video, audio_track, output_path)

--- a/src/prompt_video/text_to_image.py
+++ b/src/prompt_video/text_to_image.py
@@ -1,0 +1,73 @@
+"""Text-to-image generation optimized for the MacBook M2."""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import Any, Dict
+
+import torch
+from diffusers import StableDiffusionPipeline
+from PIL import Image, ImageStat
+
+
+@lru_cache()
+def _load_pipeline() -> StableDiffusionPipeline:
+    """Load the Stable Diffusion pipeline once and cache it."""
+    model_id = "runwayml/stable-diffusion-v1-5"
+    pipe = StableDiffusionPipeline.from_pretrained(model_id)
+    device = "mps" if torch.backends.mps.is_available() else "cpu"
+    pipe = pipe.to(device)
+    pipe.safety_checker = None  # speed up
+    return pipe
+
+
+_STYLE_PRESETS: Dict[str, str] = {
+    "photographic": "",
+    "illustration": ", clean digital art",
+    "animation": ", simple animation style",
+    "cinematic": ", film still, cinematic lighting",
+    "sketch": ", artistic sketch",
+}
+
+
+def _apply_style(prompt: str, style: str) -> str:
+    suffix = _STYLE_PRESETS.get(style.lower(), "")
+    return prompt + suffix
+
+
+def _check_image_quality(image: Image.Image) -> bool:
+    """Very small heuristic to detect nearly blank images."""
+    stat = ImageStat.Stat(image)
+    # Use average channel standard deviation as simple metric
+    return max(stat.stddev) > 5
+
+
+def generate_image(
+    prompt: str,
+    *,
+    style: str = "photographic",
+    aspect_ratio: str = "1:1",
+    upscale_to: int | None = 768,
+) -> Image.Image:
+    """Generate an image from text using Stable Diffusion."""
+    pipe = _load_pipeline()
+
+    styled_prompt = _apply_style(prompt, style)
+    width, height = 512, 512
+    if aspect_ratio == "16:9":
+        height = int(width * 9 / 16)
+    elif aspect_ratio == "9:16":
+        width = int(height * 9 / 16)
+
+    result = pipe(prompt=styled_prompt, width=width, height=height, num_inference_steps=25)
+    image = result.images[0]
+
+    if not _check_image_quality(image):
+        # One retry for extremely bad outputs
+        result = pipe(prompt=styled_prompt, width=width, height=height, num_inference_steps=25)
+        image = result.images[0]
+
+    if upscale_to:
+        image = image.resize((upscale_to, int(upscale_to * height / width)), Image.Resampling.LANCZOS)
+
+    return image


### PR DESCRIPTION
## Summary
- improve README with info about new image generation options
- add style presets, aspect ratio handling and simple upscaling in text-to-image
- support new options in the pipeline and API

## Testing
- `python -m py_compile src/prompt_video/text_to_image.py`
- `python -m py_compile src/prompt_video/pipeline.py src/prompt_video/main.py`
- `python -m py_compile src/prompt_video/*.py`


------
https://chatgpt.com/codex/tasks/task_e_684554282700832d8ea9e9f3dac13ee1