### PR TITLE
Add preview mode and tilt motion

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ prompt and optional parameters. The server returns a task ID:
 Check progress with `GET /progress/{task_id}`. When the status is
 ``done`` the response will include the ``output_path``.
 
+Intermediate files created during processing are automatically deleted
+after assembly to keep disk usage low.
+
 
 ## Gradio Interface
 

--- a/README.md
+++ b/README.md
@@ -26,9 +26,11 @@ Available voices:
 - ``male_2`` – South African accent
 - ``male_3`` – Irish accent
 
-The image-to-video step supports ``pan`` (default), ``tilt`` and
-``zoom`` motions. Use ``preview": true`` in your request to quickly
-generate a 1-second draft clip before rendering the full video.
+The image-to-video step supports several motion presets such as
+``pan_left``/``pan_right`` (``pan``), ``tilt_up``/``tilt_down`` (``tilt``),
+``zoom_in``/``zoom_out``, ``rotate`` and ``static``. Use ``preview": true``
+in your request to quickly generate a 1-second draft clip before
+rendering the full video.
 
 ## Structure
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,66 @@
-# prompt_video
+# Prompt Video Pipeline
+
+This repository contains a skeleton implementation of a text-to-video
+pipeline optimized for the MacBook Pro M2. The goal is to demonstrate an
+architecture capable of converting text prompts into short multimedia
+videos using a sequence of lightweight processing steps.
+
+The current implementation contains a working text-to-image generator
+using Stable Diffusion through the `diffusers` library. Style presets,
+aspect ratio options and a simple upscaling step are implemented.
+
+Phase 3 begins with a lightweight image-to-video component based on
+`moviepy` plus a TTS step using `gTTS` (which requires an internet
+connection). Other stages remain placeholders and should be expanded
+with Apple Silicon optimizations as described in the project
+specification. The ``voice`` option now selects among six accent-based
+presets.
+
+Available voices:
+
+- ``female_1`` – US accent
+- ``female_2`` – UK accent
+- ``female_3`` – Canadian accent
+- ``male_1`` – Australian accent
+- ``male_2`` – South African accent
+- ``male_3`` – Irish accent
+
+The image-to-video step supports ``pan`` (default), ``tilt`` and
+``zoom`` motions. Use ``preview": true`` in your request to quickly
+generate a 1-second draft clip before rendering the full video.
+
+## Structure
+
+- `src/prompt_video/` – Python package with pipeline modules
+- `pyproject.toml` – project configuration and dependencies
+
+## Running
+
+Install dependencies (including PyTorch and Diffusers) and start the FastAPI server:
+
+```bash
+pip install -e .
+uvicorn prompt_video.main:app --reload
+```
+
+Then send a POST request to `/generate` with a JSON body containing your
+prompt and optional parameters. The server returns a task ID:
+
+```json
+{
+  "prompt": "a tranquil forest",
+  "style": "cinematic",
+  "aspect_ratio": "16:9",
+  "voice": "female_1",
+  "motion": "tilt",
+  "preview": true
+}
+```
+
+```json
+{"task_id": "20230101_123000"}
+```
+
+Check progress with `GET /progress/{task_id}`. When the status is
+``done`` the response will include the ``output_path``.
+

--- a/README.md
+++ b/README.md
@@ -65,6 +65,19 @@ Check progress with `GET /progress/{task_id}`. When the status is
 ``done`` the response will include the ``output_path``.
 
 
+## Gradio Interface
+
+With the API server running you can launch a simple Gradio interface:
+
+```bash
+python ui.py
+```
+
+Fill in your prompt and options then click **Generate**. The interface
+polls the API for progress and displays the resulting video when
+finished.
+
+
 The pipeline optionally applies lip sync using the `Wav2Lip` model if it
 is installed. Provide a path to the model weights via the ``checkpoint``
 parameter in ``lip_sync.apply_lip_sync`` or place ``wav2lip_gan.pth`` in

--- a/README.md
+++ b/README.md
@@ -64,3 +64,9 @@ prompt and optional parameters. The server returns a task ID:
 Check progress with `GET /progress/{task_id}`. When the status is
 ``done`` the response will include the ``output_path``.
 
+
+The pipeline optionally applies lip sync using the `Wav2Lip` model if it
+is installed. Provide a path to the model weights via the ``checkpoint``
+parameter in ``lip_sync.apply_lip_sync`` or place ``wav2lip_gan.pth`` in
+the current directory. When the package is missing, the step is skipped.
+

--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@ architecture capable of converting text prompts into short multimedia
 videos using a sequence of lightweight processing steps.
 
 The current implementation contains a working text-to-image generator
-using Stable Diffusion through the `diffusers` library. Style presets,
-aspect ratio options and a simple upscaling step are implemented.
+using Stable Diffusion through the `diffusers` library. The model loads
+in half precision to reduce memory usage. Style presets, aspect ratio
+options and a simple upscaling step are implemented.
 
 Phase 3 begins with a lightweight image-to-video component based on
 `moviepy` plus a TTS step using `gTTS` (which requires an internet

--- a/README.md
+++ b/README.md
@@ -70,7 +70,6 @@ Check progress with `GET /progress/{task_id}`. When the status is
 Intermediate files created during processing are automatically deleted
 after assembly to keep disk usage low.
 
-
 ## Gradio Interface
 
 With the API server running you can launch a simple Gradio interface:
@@ -83,9 +82,7 @@ Fill in your prompt and options then click **Generate**. The interface
 polls the API for progress and displays the resulting video when
 finished.
 
-
 The pipeline optionally applies lip sync using the `Wav2Lip` model if it
 is installed. Provide a path to the model weights via the ``checkpoint``
 parameter in ``lip_sync.apply_lip_sync`` or place ``wav2lip_gan.pth`` in
 the current directory. When the package is missing, the step is skipped.
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,18 @@
+[project]
+name = "prompt_video"
+version = "0.1.0"
+requires-python = ">=3.10"
+dependencies = [
+    "fastapi",
+    "uvicorn[standard]",
+    "pillow",
+    "torch",
+    "diffusers",
+    "transformers",
+    "moviepy",
+    "gTTS",
+]
+
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "transformers",
     "moviepy",
     "gTTS",
+    "opencv-python",
 ]
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,8 @@ dependencies = [
     "moviepy",
     "gTTS",
     "opencv-python",
+    "gradio",
+    "requests",
 ]
 
 [build-system]

--- a/src/prompt_video/assembly.py
+++ b/src/prompt_video/assembly.py
@@ -1,0 +1,28 @@
+"""Final video assembly using ``moviepy``."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+from moviepy.editor import AudioFileClip, VideoFileClip
+
+
+def assemble_video(
+    video_path: str,
+    audio_path: Optional[str],
+    output_path: str,
+) -> None:
+    """Combine video and optional audio into the final file."""
+
+    path = Path(output_path)
+    clip = VideoFileClip(video_path)
+    if audio_path:
+        audio_clip = AudioFileClip(audio_path)
+        clip = clip.set_audio(audio_clip)
+    clip.write_videofile(
+        path.as_posix(), codec="libx264", fps=24, verbose=False, logger=None
+    )
+    clip.close()
+    if audio_path:
+        audio_clip.close()

--- a/src/prompt_video/audio_generation.py
+++ b/src/prompt_video/audio_generation.py
@@ -1,0 +1,75 @@
+"""Audio generation module optimized for Apple Silicon."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+import numpy as np
+from gtts import gTTS
+from moviepy.editor import AudioClip
+
+
+_VOICE_PROFILES = {
+    "female_1": {"lang": "en", "tld": "com"},
+    "female_2": {"lang": "en", "tld": "co.uk"},
+    "female_3": {"lang": "en", "tld": "ca"},
+    "male_1": {"lang": "en", "tld": "com.au"},
+    "male_2": {"lang": "en", "tld": "co.za"},
+    "male_3": {"lang": "en", "tld": "ie"},
+}
+
+
+def generate_voice(
+    text: str,
+    voice: str = "female_1",
+    *,
+    lang: str = "en",
+    output_path: str = "speech.mp3",
+) -> str:
+    """Generate speech audio from text using ``gTTS``.
+
+    The ``voice`` argument selects among simple accent presets based on
+    ``gTTS``'s ``tld`` option. Internet access is required for synthesis.
+    """
+
+    params = _VOICE_PROFILES.get(voice, {"lang": lang})
+    tts = gTTS(
+        text=text,
+        lang=params.get("lang", lang),
+        tld=params.get("tld", "com"),
+    )
+    path = Path(output_path)
+    tts.save(path.as_posix())
+    return path.as_posix()
+
+
+def generate_music(
+    style: str = "ambient",
+    *,
+    duration: int = 15,
+    output_path: Optional[str] = None,
+) -> Optional[str]:
+    """Generate a simple tone as placeholder background music."""
+
+    if output_path is None:
+        return None
+
+    frequency_map = {
+        "ambient": 220,
+        "upbeat": 440,
+        "dramatic": 330,
+        "peaceful": 250,
+    }
+    freq = frequency_map.get(style, 220)
+
+    def make_frame(t: float) -> list[float]:
+        return [0.2 * np.sin(2 * np.pi * freq * t)]
+
+    clip = AudioClip(make_frame, duration=duration, fps=44100)
+    path = Path(output_path)
+    clip.write_audiofile(
+        path.as_posix(), fps=44100, verbose=False, logger=None
+    )
+    clip.close()
+    return path.as_posix()

--- a/src/prompt_video/image_to_video.py
+++ b/src/prompt_video/image_to_video.py
@@ -1,0 +1,68 @@
+"""Image-to-video generation optimized for Apple Silicon."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+from PIL import Image
+from moviepy.editor import ImageClip, vfx
+
+
+def generate_video(
+    image: Image.Image,
+    motion: str = "pan",
+    *,
+    duration: int = 4,
+    fps: int = 24,
+    output_path: str = "image_video.mp4",
+    preview: bool = False,
+) -> str:
+    """Generate a short video clip from a PIL image.
+
+    This uses ``moviepy`` to create a lightweight animation. ``motion``
+    currently supports ``pan`` (horizontal), ``tilt`` (vertical), and
+    ``zoom``. In ``preview`` mode only a short 1-second clip is rendered.
+    """
+
+    if preview:
+        duration = min(duration, 1)
+
+    array = np.array(image)
+    clip = ImageClip(array).set_duration(duration)
+
+    if motion == "zoom":
+        clip = clip.fx(vfx.resize, lambda t: 1 + 0.1 * (t / duration))
+    elif motion == "pan":
+        original_w = clip.w
+        clip = clip.fx(vfx.resize, 1.1)
+        pan_range = clip.w - original_w
+
+        def crop_func(get_frame, t):
+            x = int(pan_range * (t / duration))
+            return get_frame(t)[:, x:x + original_w]
+
+        clip = clip.fl(crop_func)
+    elif motion == "tilt":
+        original_h = clip.h
+        clip = clip.fx(vfx.resize, 1.1)
+        pan_range = clip.h - original_h
+
+        def crop_func(get_frame, t):
+            y = int(pan_range * (t / duration))
+            return get_frame(t)[y:y + original_h, :]
+
+        clip = clip.fl(crop_func)
+
+    path = Path(output_path)
+    clip.write_videofile(
+        path.as_posix(),
+        fps=fps,
+        codec="libx264",
+        audio=False,
+        verbose=False,
+        logger=None,
+    )
+    clip.close()
+    return path.as_posix()

--- a/src/prompt_video/image_to_video.py
+++ b/src/prompt_video/image_to_video.py
@@ -22,8 +22,11 @@ def generate_video(
     """Generate a short video clip from a PIL image.
 
     This uses ``moviepy`` to create a lightweight animation. ``motion``
-    currently supports ``pan`` (horizontal), ``tilt`` (vertical), and
-    ``zoom``. In ``preview`` mode only a short 1-second clip is rendered.
+    supports several presets including ``pan_left``/``pan_right``,
+    ``tilt_up``/``tilt_down``, ``zoom_in``/``zoom_out``, ``rotate`` and
+    ``static``. ``pan`` and ``tilt`` are aliases for ``pan_right`` and
+    ``tilt_down``. In ``preview`` mode only a short 1-second clip is
+    rendered.
     """
 
     if preview:
@@ -32,9 +35,11 @@ def generate_video(
     array = np.array(image)
     clip = ImageClip(array).set_duration(duration)
 
-    if motion == "zoom":
+    if motion in {"zoom", "zoom_in"}:
         clip = clip.fx(vfx.resize, lambda t: 1 + 0.1 * (t / duration))
-    elif motion == "pan":
+    elif motion == "zoom_out":
+        clip = clip.fx(vfx.resize, lambda t: 1.1 - 0.1 * (t / duration))
+    elif motion in {"pan", "pan_right"}:
         original_w = clip.w
         clip = clip.fx(vfx.resize, 1.1)
         pan_range = clip.w - original_w
@@ -44,7 +49,17 @@ def generate_video(
             return get_frame(t)[:, x:x + original_w]
 
         clip = clip.fl(crop_func)
-    elif motion == "tilt":
+    elif motion == "pan_left":
+        original_w = clip.w
+        clip = clip.fx(vfx.resize, 1.1)
+        pan_range = clip.w - original_w
+
+        def crop_func(get_frame, t):
+            x = int(pan_range * (1 - (t / duration)))
+            return get_frame(t)[:, x:x + original_w]
+
+        clip = clip.fl(crop_func)
+    elif motion in {"tilt", "tilt_down"}:
         original_h = clip.h
         clip = clip.fx(vfx.resize, 1.1)
         pan_range = clip.h - original_h
@@ -54,6 +69,18 @@ def generate_video(
             return get_frame(t)[y:y + original_h, :]
 
         clip = clip.fl(crop_func)
+    elif motion == "tilt_up":
+        original_h = clip.h
+        clip = clip.fx(vfx.resize, 1.1)
+        pan_range = clip.h - original_h
+
+        def crop_func(get_frame, t):
+            y = int(pan_range * (1 - (t / duration)))
+            return get_frame(t)[y:y + original_h, :]
+
+        clip = clip.fl(crop_func)
+    elif motion == "rotate":
+        clip = clip.fx(vfx.rotate, lambda t: -5 + 10 * (t / duration))
 
     path = Path(output_path)
     clip.write_videofile(

--- a/src/prompt_video/lip_sync.py
+++ b/src/prompt_video/lip_sync.py
@@ -1,0 +1,15 @@
+"""Lip sync processing module optimized for Apple Silicon."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+
+def apply_lip_sync(video_path: str, audio_path: Optional[str]) -> str:
+    """Apply lip sync to a video clip given speech audio.
+
+    This placeholder simply returns ``video_path`` unchanged.
+    """
+
+    print("Applying lip sync to video")
+    return video_path

--- a/src/prompt_video/lip_sync.py
+++ b/src/prompt_video/lip_sync.py
@@ -1,15 +1,61 @@
-"""Lip sync processing module optimized for Apple Silicon."""
+"""Lip sync processing module optimized for Apple Silicon.
+
+This implementation attempts to run the `Wav2Lip` command line
+interface when available. If the package or its dependencies are not
+installed, the function simply returns the original video path. The
+`checkpoint` argument should point to a pre-trained ``.pth`` model file.
+"""
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Optional
 
+import importlib.util
+import subprocess
 
-def apply_lip_sync(video_path: str, audio_path: Optional[str]) -> str:
+
+def apply_lip_sync(
+    video_path: str,
+    audio_path: Optional[str],
+    *,
+    checkpoint: str | None = None,
+) -> str:
     """Apply lip sync to a video clip given speech audio.
 
-    This placeholder simply returns ``video_path`` unchanged.
+    If ``Wav2Lip`` is not installed, the function prints a message and
+    returns ``video_path`` unchanged. ``checkpoint`` should reference the
+    model weights file required by Wav2Lip.
     """
 
-    print("Applying lip sync to video")
-    return video_path
+    if audio_path is None:
+        return video_path
+
+    if importlib.util.find_spec("wav2lip") is None:
+        print("Wav2Lip not installed; skipping lip sync")
+        return video_path
+
+    base = Path(video_path)
+    out_path = base.with_name(f"{base.stem}_lipsync.mp4")
+    cmd = [
+        "python",
+        "-m",
+        "wav2lip",
+        "--checkpoint",
+        checkpoint or "wav2lip_gan.pth",
+        "--face",
+        video_path,
+        "--audio",
+        audio_path,
+        "--outfile",
+        out_path.as_posix(),
+        "--nosmooth",
+    ]
+
+    try:
+        subprocess.run(cmd, check=True)
+    except Exception as exc:  # pragma: no cover - best effort
+        print(f"Wav2Lip failed: {exc}")
+        return video_path
+
+    return out_path.as_posix()

--- a/src/prompt_video/main.py
+++ b/src/prompt_video/main.py
@@ -20,7 +20,7 @@ class GenerateRequest(BaseModel):
     style: str = "photographic"
     aspect_ratio: str = "1:1"
     motion: str = "pan"
-    voice: str = "female"
+    voice: str = "female_1"
     music_style: str = "ambient"
     preview: bool = False
 

--- a/src/prompt_video/main.py
+++ b/src/prompt_video/main.py
@@ -1,0 +1,74 @@
+"""FastAPI app exposing the text-to-video pipeline."""
+
+import asyncio
+from datetime import datetime
+from typing import Any, Dict
+
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+from . import pipeline
+
+app = FastAPI(title="Prompt Video Pipeline")
+
+_tasks: Dict[str, Dict[str, Any]] = {}
+_queue: asyncio.Queue = asyncio.Queue()
+
+
+class GenerateRequest(BaseModel):
+    prompt: str
+    style: str = "photographic"
+    aspect_ratio: str = "1:1"
+    motion: str = "pan"
+    voice: str = "female"
+    music_style: str = "ambient"
+    preview: bool = False
+
+
+async def _worker() -> None:
+    while True:
+        task_id, req, output_path = await _queue.get()
+
+        def update(stage: str) -> None:
+            _tasks[task_id]["status"] = stage
+
+        _tasks[task_id]["status"] = "running"
+        try:
+            out = await asyncio.to_thread(
+                pipeline.generate_video_from_text,
+                req.prompt,
+                output_path,
+                style=req.style,
+                aspect_ratio=req.aspect_ratio,
+                motion=req.motion,
+                voice=req.voice,
+                music_style=req.music_style,
+                preview=req.preview,
+                progress_callback=update,
+            )
+            _tasks[task_id]["status"] = "done"
+            _tasks[task_id]["output_path"] = out
+        except Exception as exc:  # pragma: no cover - simple logging
+            _tasks[task_id]["status"] = "error"
+            _tasks[task_id]["error"] = str(exc)
+        _queue.task_done()
+
+
+@app.on_event("startup")
+async def _startup() -> None:
+    asyncio.create_task(_worker())
+
+
+@app.post("/generate")
+async def generate(req: GenerateRequest):
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    output_path = f"output_{timestamp}.mp4"
+    task_id = timestamp
+    _tasks[task_id] = {"status": "queued", "output_path": None}
+    await _queue.put((task_id, req, output_path))
+    return {"task_id": task_id}
+
+
+@app.get("/progress/{task_id}")
+async def progress(task_id: str):
+    return _tasks.get(task_id, {"status": "unknown"})

--- a/src/prompt_video/pipeline.py
+++ b/src/prompt_video/pipeline.py
@@ -1,0 +1,104 @@
+"""Sequential text-to-video pipeline optimized for the MacBook M2."""
+
+from datetime import datetime
+from pathlib import Path
+from typing import Optional, Callable
+
+import gc
+
+from . import (
+    text_to_image,
+    image_to_video,
+    audio_generation,
+    lip_sync,
+    assembly,
+)
+
+
+def generate_video_from_text(
+    prompt: str,
+    output_path: str,
+    *,
+    style: str = "photographic",
+    aspect_ratio: str = "1:1",
+    motion: str = "pan",
+    voice: str = "female",
+    music_style: str = "ambient",
+    preview: bool = False,
+    progress_callback: Callable[[str], None] | None = None,
+) -> str:
+    """Run the entire pipeline from text prompt to final video file.
+
+    Set ``preview=True`` to generate a quick 1-second draft video.
+    Returns the path to the generated video.
+    """
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    base = Path(output_path)
+    tmp_video = base.with_name(f"{base.stem}_{timestamp}_image.mp4")
+    speech_file = base.with_name(f"{base.stem}_{timestamp}_speech.mp3")
+    music_file = base.with_name(f"{base.stem}_{timestamp}_music.mp3")
+
+    image = text_to_image.generate_image(
+        prompt, style=style, aspect_ratio=aspect_ratio
+    )
+    if progress_callback:
+        progress_callback("image")
+    video_path = image_to_video.generate_video(
+        image,
+        motion=motion,
+        output_path=tmp_video.as_posix(),
+        preview=preview,
+    )
+    del image
+    gc.collect()
+    if progress_callback:
+        progress_callback("video")
+    speech_path = audio_generation.generate_voice(
+        prompt, voice=voice, output_path=speech_file.as_posix()
+    )
+    if progress_callback:
+        progress_callback("speech")
+    music_path = audio_generation.generate_music(
+        style=music_style, output_path=music_file.as_posix()
+    )
+    if progress_callback:
+        progress_callback("music")
+
+    mixed_audio: Optional[str]
+    if speech_path and music_path:
+        from moviepy.editor import (
+            AudioFileClip,
+            CompositeAudioClip,
+        )
+
+        mixed_file = base.with_name(f"{base.stem}_{timestamp}_mix.mp3")
+        speech_clip = AudioFileClip(speech_path)
+        music_clip = AudioFileClip(music_path).volumex(0.5)
+        composite = CompositeAudioClip([music_clip, speech_clip])
+        composite.write_audiofile(
+            mixed_file.as_posix(), verbose=False, logger=None
+        )
+        speech_clip.close()
+        music_clip.close()
+        composite.close()
+        mixed_audio = mixed_file.as_posix()
+    else:
+        mixed_audio = speech_path or music_path
+
+    if progress_callback:
+        progress_callback("audio_mixed")
+
+    synced_video_path = lip_sync.apply_lip_sync(video_path, speech_path)
+    if progress_callback:
+        progress_callback("lip_sync")
+    assembly.assemble_video(synced_video_path, mixed_audio, output_path)
+    if progress_callback:
+        progress_callback("assembly")
+    del video_path
+    gc.collect()
+    del speech_path
+    del music_path
+    gc.collect()
+    if progress_callback:
+        progress_callback("done")
+    return output_path

--- a/src/prompt_video/pipeline.py
+++ b/src/prompt_video/pipeline.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Optional, Callable
 
 import gc
+import os
 
 from . import (
     text_to_image,
@@ -13,6 +14,14 @@ from . import (
     lip_sync,
     assembly,
 )
+
+
+def _safe_unlink(path: str | Path) -> None:
+    """Remove a file if it exists, ignoring errors."""
+    try:
+        Path(path).unlink(missing_ok=True)
+    except OSError:
+        pass
 
 
 def generate_video_from_text(
@@ -94,11 +103,22 @@ def generate_video_from_text(
     assembly.assemble_video(synced_video_path, mixed_audio, output_path)
     if progress_callback:
         progress_callback("assembly")
+
+    _safe_unlink(tmp_video)
+    if synced_video_path != tmp_video.as_posix():
+        _safe_unlink(synced_video_path)
+    if speech_path:
+        _safe_unlink(speech_path)
+    if music_path:
+        _safe_unlink(music_path)
+    if mixed_audio and mixed_audio not in {speech_path, music_path}:
+        _safe_unlink(mixed_audio)
+
     del video_path
-    gc.collect()
     del speech_path
     del music_path
     gc.collect()
+
     if progress_callback:
         progress_callback("done")
     return output_path

--- a/src/prompt_video/pipeline.py
+++ b/src/prompt_video/pipeline.py
@@ -31,7 +31,7 @@ def generate_video_from_text(
     style: str = "photographic",
     aspect_ratio: str = "1:1",
     motion: str = "pan",
-    voice: str = "female",
+    voice: str = "female_1",
     music_style: str = "ambient",
     preview: bool = False,
     progress_callback: Callable[[str], None] | None = None,

--- a/src/prompt_video/pipeline.py
+++ b/src/prompt_video/pipeline.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from typing import Optional, Callable
 
 import gc
-import os
 
 from . import (
     text_to_image,
@@ -75,10 +74,7 @@ def generate_video_from_text(
 
     mixed_audio: Optional[str]
     if speech_path and music_path:
-        from moviepy.editor import (
-            AudioFileClip,
-            CompositeAudioClip,
-        )
+        from moviepy.editor import AudioFileClip, CompositeAudioClip
 
         mixed_file = base.with_name(f"{base.stem}_{timestamp}_mix.mp3")
         speech_clip = AudioFileClip(speech_path)

--- a/src/prompt_video/text_to_image.py
+++ b/src/prompt_video/text_to_image.py
@@ -14,7 +14,10 @@ from PIL import Image, ImageStat
 def _load_pipeline() -> StableDiffusionPipeline:
     """Load the Stable Diffusion pipeline once and cache it."""
     model_id = "runwayml/stable-diffusion-v1-5"
-    pipe = StableDiffusionPipeline.from_pretrained(model_id)
+    pipe = StableDiffusionPipeline.from_pretrained(
+        model_id,
+        torch_dtype=torch.float16,
+    )
     device = "mps" if torch.backends.mps.is_available() else "cpu"
     pipe = pipe.to(device)
     pipe.safety_checker = None  # speed up

--- a/src/prompt_video/text_to_image.py
+++ b/src/prompt_video/text_to_image.py
@@ -1,0 +1,86 @@
+"""Text-to-image generation optimized for the MacBook M2."""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import Any, Dict
+
+import torch
+from diffusers import StableDiffusionPipeline
+from PIL import Image, ImageStat
+
+
+@lru_cache()
+def _load_pipeline() -> StableDiffusionPipeline:
+    """Load the Stable Diffusion pipeline once and cache it."""
+    model_id = "runwayml/stable-diffusion-v1-5"
+    pipe = StableDiffusionPipeline.from_pretrained(model_id)
+    device = "mps" if torch.backends.mps.is_available() else "cpu"
+    pipe = pipe.to(device)
+    pipe.safety_checker = None  # speed up
+    return pipe
+
+
+_STYLE_PRESETS: Dict[str, str] = {
+    "photographic": "",
+    "illustration": ", clean digital art",
+    "animation": ", simple animation style",
+    "cinematic": ", film still, cinematic lighting",
+    "sketch": ", artistic sketch",
+}
+
+
+def _apply_style(prompt: str, style: str) -> str:
+    suffix = _STYLE_PRESETS.get(style.lower(), "")
+    return prompt + suffix
+
+
+def _check_image_quality(image: Image.Image) -> bool:
+    """Very small heuristic to detect nearly blank images."""
+    stat = ImageStat.Stat(image)
+    # Use average channel standard deviation as simple metric
+    return max(stat.stddev) > 5
+
+
+def generate_image(
+    prompt: str,
+    *,
+    style: str = "photographic",
+    aspect_ratio: str = "1:1",
+    upscale_to: int | None = 768,
+) -> Image.Image:
+    """Generate an image from text using Stable Diffusion."""
+    pipe = _load_pipeline()
+
+    styled_prompt = _apply_style(prompt, style)
+    width, height = 512, 512
+    if aspect_ratio == "16:9":
+        height = int(width * 9 / 16)
+    elif aspect_ratio == "9:16":
+        width = int(height * 9 / 16)
+
+    result = pipe(
+        prompt=styled_prompt,
+        width=width,
+        height=height,
+        num_inference_steps=25,
+    )
+    image = result.images[0]
+
+    if not _check_image_quality(image):
+        # One retry for extremely bad outputs
+        result = pipe(
+            prompt=styled_prompt,
+            width=width,
+            height=height,
+            num_inference_steps=25,
+        )
+        image = result.images[0]
+
+    if upscale_to:
+        image = image.resize(
+            (upscale_to, int(upscale_to * height / width)),
+            Image.Resampling.LANCZOS,
+        )
+
+    return image

--- a/ui.py
+++ b/ui.py
@@ -12,7 +12,16 @@ styles = [
     "sketch",
 ]
 aspect_ratios = ["1:1", "16:9", "9:16"]
-motions = ["pan", "tilt", "zoom"]
+motions = [
+    "pan_right",
+    "pan_left",
+    "tilt_down",
+    "tilt_up",
+    "zoom_in",
+    "zoom_out",
+    "rotate",
+    "static",
+]
 voices = ["female_1", "female_2", "female_3", "male_1", "male_2", "male_3"]
 music_styles = ["ambient", "upbeat", "dramatic", "peaceful"]
 
@@ -57,7 +66,7 @@ with gr.Blocks() as demo:
         aspect_dd = gr.Dropdown(
             aspect_ratios, value="1:1", label="Aspect Ratio"
         )
-        motion_dd = gr.Dropdown(motions, value="pan", label="Motion")
+        motion_dd = gr.Dropdown(motions, value="pan_right", label="Motion")
     with gr.Row():
         voice_dd = gr.Dropdown(voices, value="female_1", label="Voice")
         music_dd = gr.Dropdown(

--- a/ui.py
+++ b/ui.py
@@ -1,0 +1,84 @@
+import time
+import requests
+import gradio as gr
+
+API_URL = "http://localhost:8000"
+
+styles = [
+    "photographic",
+    "illustration",
+    "animation",
+    "cinematic",
+    "sketch",
+]
+aspect_ratios = ["1:1", "16:9", "9:16"]
+motions = ["pan", "tilt", "zoom"]
+voices = ["female_1", "female_2", "female_3", "male_1", "male_2", "male_3"]
+music_styles = ["ambient", "upbeat", "dramatic", "peaceful"]
+
+
+def run_generation(prompt, style, aspect_ratio, motion, voice, music_style,
+                   preview):
+    resp = requests.post(
+        f"{API_URL}/generate",
+        json={
+            "prompt": prompt,
+            "style": style,
+            "aspect_ratio": aspect_ratio,
+            "motion": motion,
+            "voice": voice,
+            "music_style": music_style,
+            "preview": preview,
+        },
+        timeout=10,
+    )
+    task_id = resp.json()["task_id"]
+    status = "queued"
+    output_path = None
+    while status not in {"done", "error"}:
+        time.sleep(1)
+        r = requests.get(f"{API_URL}/progress/{task_id}", timeout=10)
+        data = r.json()
+        status = data.get("status", "error")
+        output_path = data.get("output_path")
+    if status == "done" and output_path:
+        return output_path
+    raise gr.Error(data.get("error", "Generation failed"))
+
+
+with gr.Blocks() as demo:
+    gr.Markdown("# Prompt Video Generator")
+    with gr.Row():
+        prompt = gr.Textbox(label="Prompt")
+    with gr.Row():
+        style_dd = gr.Dropdown(
+            styles, value="photographic", label="Style"
+        )
+        aspect_dd = gr.Dropdown(
+            aspect_ratios, value="1:1", label="Aspect Ratio"
+        )
+        motion_dd = gr.Dropdown(motions, value="pan", label="Motion")
+    with gr.Row():
+        voice_dd = gr.Dropdown(voices, value="female_1", label="Voice")
+        music_dd = gr.Dropdown(
+            music_styles, value="ambient", label="Music Style"
+        )
+        preview_cb = gr.Checkbox(label="Preview", value=False)
+    gen_btn = gr.Button("Generate")
+    output = gr.Video(label="Result")
+    gen_btn.click(
+        run_generation,
+        [
+            prompt,
+            style_dd,
+            aspect_dd,
+            motion_dd,
+            voice_dd,
+            music_dd,
+            preview_cb,
+        ],
+        output,
+    )
+
+demo.queue()
+demo.launch()


### PR DESCRIPTION
## Summary
- add tilt motion option in `image_to_video.generate_video`
- support a preview flag that renders a short 1-second clip
- expose preview option through pipeline and API
- update README usage example and documentation

## Testing
- `pycodestyle src/prompt_video`
- `python -m py_compile src/prompt_video/*.py`


------
https://chatgpt.com/codex/tasks/task_e_684554282700832d8ea9e9f3dac13ee1